### PR TITLE
Fixed wasm paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 # JetBrains IDEs
 .idea
 
-substrate-runtime-joystream
+dappforce-subsocial-runtime

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -191,7 +191,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 
     GenesisConfig {
 		consensus: Some(ConsensusConfig {
-			code: include_bytes!("../substrate-runtime-joystream/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm").to_vec(),
+			code: include_bytes!("../dappforce-subsocial-runtime/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm").to_vec(),
 			authorities: initial_authorities.iter().map(|x| x.2.clone()).collect(),
 		}),
 		system: None,
@@ -293,7 +293,7 @@ fn testnet_genesis(
 
     GenesisConfig {
 		consensus: Some(ConsensusConfig {
-			code: include_bytes!("../substrate-runtime-joystream/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm").to_vec(),
+			code: include_bytes!("../dappforce-subsocial-runtime/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm").to_vec(),
 			authorities: initial_authorities.iter().map(|x| x.2.clone()).collect(),
 		}),
 		system: None,

--- a/src/service.rs
+++ b/src/service.rs
@@ -51,7 +51,7 @@ native_executor_instance!(
 	pub Executor,
 	joystream_node_runtime::api::dispatch,
 	joystream_node_runtime::native_version,
-	include_bytes!("../substrate-runtime-joystream/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm")
+	include_bytes!("../dappforce-subsocial-runtime/wasm/target/wasm32-unknown-unknown/release/joystream_node_runtime_wasm.compact.wasm")
 );
 
 pub struct NodeConfig<F: substrate_service::ServiceFactory> {


### PR DESCRIPTION
Now there's no errors on executing build-clean-start.sh